### PR TITLE
Push Docker images to AWS ECR

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,8 +1,8 @@
 name: Build, push to AWS ECR, and deploy
-on: push
-  # push:
-  #   branches:
-  #     - master
+on:
+  push:
+    branches:
+      - master
 
 env:
   AWS_REGION: ca-central-1

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,8 +1,8 @@
 name: Build, push to AWS ECR, and deploy
-on:
-  push:
-    branches:
-      - master
+on: push
+  # push:
+  #   branches:
+  #     - master
 
 env:
   AWS_REGION: ca-central-1

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,38 +1,60 @@
-name: Build, push to GCR, and deploy
+name: Build, push to AWS ECR, and deploy
 on:
   push:
-    branches:    
+    branches:
       - master
+
+env:
+  AWS_REGION: ca-central-1
+  DOCKER_ORG: public.ecr.aws/v6b8u5o6
+  DOCKER_SLUG: public.ecr.aws/v6b8u5o6/notify-document-download-frontend
+  KUBECTL_VERSION: '1.18.0'
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     name: Build and push
     steps:
-    - uses: actions/checkout@master
-    - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
-      with:
-        version: '270.0.0'
-        service_account_email: ${{ secrets.GCP_SA_EMAIL }}
-        service_account_key: ${{ secrets.GCLOUD_AUTH }}
-    - run: |
-        gcloud auth configure-docker
+    - uses: actions/checkout@v2
+    - name: Install AWS CLI
+      run: |
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+        unzip -q awscliv2.zip
+        sudo ./aws/install
+        aws --version
+    - name: Install kubectl
+      run: |
+        curl -LO https://storage.googleapis.com/kubernetes-release/release/v$KUBECTL_VERSION/bin/linux/amd64/kubectl
+        chmod +x ./kubectl
+        sudo mv ./kubectl /usr/local/bin/kubectl
+        kubectl version --client
+        mkdir -p $HOME/.kube
+    - name: AWS auth with ECR
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ECR_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_ECR_SECRET_ACCESS_KEY }}
+      run: |
+        aws ecr-public get-login-password --region us-east-1 > /tmp/aws
+        cat /tmp/aws | docker login --username AWS --password-stdin $DOCKER_ORG
+        rm /tmp/aws
     - name: Build
-      run: |        
-        docker build -t gcr.io/cdssnc/notify/document-download-frontend:${GITHUB_SHA::7} -t gcr.io/cdssnc/notify/document-download-frontend:latest -f ci/Dockerfile .
+      run: |
+        docker build --build-arg GIT_SHA=${GITHUB_SHA::7} -t $DOCKER_SLUG:${GITHUB_SHA::7} -t $DOCKER_SLUG:latest -f ci/Dockerfile .
     - name: Publish
       run: |
-        docker push gcr.io/cdssnc/notify/document-download-frontend:latest && docker push gcr.io/cdssnc/notify/document-download-frontend:${GITHUB_SHA::7}
-    - name: EKS
-      uses: docker://gcr.io/cdssnc/aws:latest
+        docker push $DOCKER_SLUG:latest && docker push $DOCKER_SLUG:${GITHUB_SHA::7}
+    - name: Get Kubernetes configuration
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      with:
-        args: eks --region ca-central-1 update-kubeconfig --name notification-canada-ca-staging-eks-cluster
-    - name: Apply
-      uses: docker://gcr.io/cdssnc/aws-kubectl:latest
+      run: |
+        aws eks --region $AWS_REGION update-kubeconfig --name notification-canada-ca-staging-eks-cluster --kubeconfig $HOME/.kube/config
+    - name: Update image in staging
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      with:
-        args: set image deployment.apps/document-download-frontend document-download-frontend=gcr.io/cdssnc/notify/document-download-frontend:${GITHUB_SHA::7} -n=notification-canada-ca --kubeconfig=/github/home/.kube/config
+      run: |
+        kubectl set image deployment.apps/document-download-frontend document-download-frontend=$DOCKER_SLUG:${GITHUB_SHA::7} -n=notification-canada-ca --kubeconfig=$HOME/.kube/config
+    - uses: cds-snc/notification-pr-bot@master
+      env:
+        TOKEN: ${{ secrets.PR_BOT_TOKEN }}

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -6,7 +6,7 @@ Flask-WTF==0.14.3
 
 gunicorn==20.0.4
 whitenoise==4.1.2  #manages static assets
-eventlet==0.25.1
+eventlet==0.28.0
 
 Babel==2.8.0
 Flask-Babel==1.0.0
@@ -14,6 +14,6 @@ python-dotenv==0.10.3
 notifications-python-client==5.5.1
 
 # PaaS
-awscli-cwlogs>=1.4,<1.5
+awscli-cwlogs>=1.4.6,<1.5
 
-git+https://github.com/cds-snc/notifier-utils.git@39.0.1#egg=notifications-utils==39.0.1
+git+https://github.com/cds-snc/notifier-utils.git@43.2.2#egg=notifications-utils

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Flask-WTF==0.14.3
 
 gunicorn==20.0.4
 whitenoise==4.1.2  #manages static assets
-eventlet==0.25.1
+eventlet==0.28.0
 
 Babel==2.8.0
 Flask-Babel==1.0.0
@@ -17,47 +17,50 @@ notifications-python-client==5.5.1
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/cds-snc/notifier-utils.git@39.0.1#egg=notifications-utils==39.0.1
+git+https://github.com/cds-snc/notifier-utils.git@43.2.2#egg=notifications-utils
 
 ## The following requirements were added by pip freeze:
-awscli==1.18.13
-bleach==3.1.4
-boto3==1.12.13
-botocore==1.15.13
-certifi==2019.11.28
+awscli==1.18.188
+bleach==3.2.1
+boto3==1.16.28
+botocore==1.19.28
+cachetools==4.1.1
+certifi==2020.12.5
 chardet==3.0.4
-Click==7.0
+click==7.1.2
 colorama==0.4.3
 dnspython==1.16.0
 docopt==0.6.2
 docutils==0.15.2
 flask-redis==0.4.0
 future==0.18.2
-greenlet==0.4.15
-idna==2.9
+greenlet==0.4.17
+idna==2.10
 itsdangerous==1.1.0
-Jinja2==2.11.1
-jmespath==0.9.5
+Jinja2==2.11.2
+jmespath==0.10.0
 MarkupSafe==1.1.1
 mistune==0.8.4
 monotonic==1.5
-orderedset==2.0.1
-phonenumbers==8.10.13
+orderedset==2.0.3
+packaging==20.7
+phonenumbers==8.12.12
 pyasn1==0.4.8
 PyJWT==1.7.1
+pyparsing==2.4.7
 PyPDF2==1.26.0
 python-dateutil==2.8.1
-python-json-logger==0.1.11
-pytz==2019.3
+python-json-logger==2.0.0
+pytz==2020.4
 PyYAML==5.3.1
-redis==3.4.1
-requests==2.23.0
-rsa==3.4.2
+redis==3.5.3
+requests==2.25.0
+rsa==4.5
 s3transfer==0.3.3
-six==1.14.0
+six==1.15.0
 smartypants==2.0.1
 statsd==3.3.0
-urllib3==1.25.8
+urllib3==1.26.2
 webencodings==0.5.1
-Werkzeug==1.0.0
-WTForms==2.2.1
+Werkzeug==1.0.1
+WTForms==2.3.3


### PR DESCRIPTION
Same PR than https://github.com/cds-snc/notification-admin/pull/845 in admin

Changed the trigger condition to `push` to make sure that the CI job works as intended. Pods in staging run with Docker images pulled from AWS at the moment.

Gallery link: https://gallery.ecr.aws/v6b8u5o6/notify-document-download-frontend

Bonus:
- upgraded dependencies
- added PR bot