### PR TITLE
Increase keepalive between Gunicorn and LB

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -8,6 +8,15 @@ worker_connections = 256
 bind = "0.0.0.0:{}".format(os.getenv("PORT"))
 accesslog = '-'
 
+# See AWS doc
+# > We also recommend that you configure the idle timeout of your application
+# to be larger than the idle timeout configured for the load balancer.
+# > By default, Elastic Load Balancing sets the idle timeout value for your load balancer to 60 seconds.
+# https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout
+in_production = os.environ.get("NOTIFY_ENVIRONMENT", "") == "production"
+if in_production:
+    keepalive = 75
+
 
 def on_starting(server):
     server.log.info("Starting Document Download Frontend")


### PR DESCRIPTION
Same PR than https://github.com/cds-snc/notification-admin/pull/852 and follow up https://github.com/cds-snc/notification-admin/pull/856

This app runs also with Gunicorn behind the same load balancer, we need to set the `keepalive` to the same value otherwise we risk provoking 502 errors at the load balancer level.

The `NOTIFY_ENVIRONMENT` env is not defined for this deployment, I'll do a PR for that as well.