### PR TITLE
feat: pass filename parameter to views and API

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlencode
+
 from flask import abort, current_app, render_template, request
 from notifications_python_client.errors import HTTPError
 
@@ -31,7 +33,8 @@ def landing(service_id, document_id):
         service_contact_info=service_contact_info,
         contact_info_type=contact_info_type,
         document_id=document_id,
-        key=key
+        key=key,
+        filename=request.args.get('filename'),
     )
 
 
@@ -40,12 +43,19 @@ def download_document(service_id, document_id):
     key = request.args.get('key', None)
     if not key:
         abort(404)
+    filename = request.args.get('filename')
 
-    download_link = '{}/services/{}/documents/{}?key={}'.format(
+    query_params = urlencode({
+        k: v for k, v
+        in {'key': key, 'filename': filename}.items()
+        if v
+    })
+
+    download_link = '{}/services/{}/documents/{}?{}'.format(
         current_app.config['DOCUMENT_DOWNLOAD_API_HOST_NAME'],
         service_id,
         document_id,
-        key
+        query_params,
     )
 
     try:

--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -15,6 +15,6 @@
     {% endif %}
   </p>
   <p>
-    <a href="{{url_for('main.download_document', service_id=service_id, document_id=document_id, key=key)}}" class="button">{{ _('Continue') }}</a>
+    <a href="{{url_for('main.download_document', service_id=service_id, document_id=document_id, key=key, filename=filename)}}" class="button">{{ _('Continue') }}</a>
   </p>
 {% endblock %}

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -64,6 +64,32 @@ def test_landing_page_creates_link_for_document(client, mocker, sample_service):
     )
 
 
+def test_landing_page_creates_link_for_document_with_filename(client, mocker, sample_service):
+    mocker.patch('app.service_api_client.get_service', return_value={'data': sample_service})
+    service_id = uuid4()
+    document_id = uuid4()
+    response = client.get(
+        url_for(
+            'main.landing',
+            service_id=service_id,
+            document_id=document_id,
+            key='1234',
+            filename='custom_file.pdf',
+        )
+    )
+
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+
+    assert page.find('a', string="Continue")['href'] == url_for(
+        'main.download_document',
+        service_id=service_id,
+        document_id=document_id,
+        key='1234',
+        filename='custom_file.pdf',
+    )
+
+
 def test_download_document_creates_link_to_actual_doc_from_api(client, mocker, sample_service):
     mocker.patch('app.service_api_client.get_service', return_value={'data': sample_service})
     service_id = uuid4()
@@ -86,6 +112,40 @@ def test_download_document_creates_link_to_actual_doc_from_api(client, mocker, s
         service_id,
         document_id,
         key
+    )
+
+
+def test_download_document_creates_link_to_actual_doc_from_api_with_filename(
+    client,
+    mocker,
+    sample_service
+):
+    mocker.patch('app.service_api_client.get_service', return_value={'data': sample_service})
+    service_id = uuid4()
+    document_id = uuid4()
+    key = '1234'
+    filename = 'custom_file.pdf'
+
+    response = client.get(
+        url_for(
+            'main.download_document',
+            service_id=service_id,
+            document_id=document_id,
+            key=key,
+            filename=filename
+        )
+    )
+
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+
+    assert page.select('main a')[0]['href'] == (
+        'http://test-doc-download-api/services/{}/documents/{}?key={}&filename={}'
+    ).format(
+        service_id,
+        document_id,
+        key,
+        filename,
     )
 
 


### PR DESCRIPTION
## Story
When attaching files to my email notification I want to be able to set the file name programmatically so that my recipients don't get files named with long strings of numbers and letters that aren't a11y friendly. 

## What it does

Relates to https://github.com/cds-snc/notification-document-download-api/pull/28

If the `filename` argument is passed in the query string, pass it to the 2 views and back to the API where it will be used.

Trello card: https://trello.com/c/BVIe44l5/443-let-clients-name-the-files-they-are-attaching-in-the-api