### PR TITLE
feat: redirect to file directly

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -41,7 +41,7 @@ class Test(Development):
     TESTING = True
 
     # used during tests as a domain name
-    SERVER_NAME = 'document-download-frontend'
+    SERVER_NAME = 'document-download-frontend.localdomain'
 
     API_HOST_NAME = 'http://test-notify-api'
     ADMIN_BASE_URL = 'http://test-notify-admin'

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -1,11 +1,11 @@
 from urllib.parse import urlencode
 
-from flask import abort, current_app, render_template, request
+from flask import abort, current_app, redirect, render_template, request
 from notifications_python_client.errors import HTTPError
 
 from app import service_api_client
 from app.main import main
-from app.utils import assess_contact_type
+from app.utils import assess_contact_type, download_link
 
 
 @main.route('/_status')
@@ -18,6 +18,18 @@ def landing(service_id, document_id):
     key = request.args.get('key', None)
     if not key:
         abort(404)
+
+    filename = request.args.get('filename')
+
+    return redirect(
+        download_link(
+            service_id,
+            document_id,
+            key,
+            filename
+        ),
+        code=302
+    )
 
     try:
         service = service_api_client.get_service(service_id)

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,5 +1,5 @@
 import re
-from urllib.parse import urlparse
+from urllib.parse import urlencode, urlparse
 
 from flask import current_app
 from notifications_utils.recipients import EMAIL_REGEX_PATTERN
@@ -24,3 +24,18 @@ def assess_contact_type(service_contact_info):
         return "link"
     else:
         return "other"
+
+
+def download_link(service_id, document_id, key, filename):
+    query_params = urlencode({
+        k: v for k, v
+        in {'key': key, 'filename': filename}.items()
+        if v
+    })
+
+    return '{}/services/{}/documents/{}?{}'.format(
+        current_app.config['DOCUMENT_DOWNLOAD_API_HOST_NAME'],
+        service_id,
+        document_id,
+        query_params,
+    )

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -7,6 +7,8 @@ from bs4 import BeautifulSoup
 from flask import url_for
 from notifications_python_client.errors import HTTPError
 
+from tests.conftest import skip_if_direct_download
+
 
 def test_status(client):
     response = client.get(url_for('main.status'))
@@ -25,6 +27,51 @@ def test_landing_page_404s_if_no_key_in_query_string(client):
     assert response.status_code == 404
 
 
+def test_landing_redirects_to_download_file(client):
+    service_id = uuid4()
+    document_id = uuid4()
+    key = '1234'
+    filename = "file.pdf"
+
+    response = client.get(
+        url_for(
+            'main.landing',
+            service_id=service_id,
+            document_id=document_id,
+            key=key,
+            filename=filename,
+        )
+    )
+    assert response.status_code == 302
+    assert response.headers['X-Robots-Tag'] == 'noindex, nofollow'
+    expected_url = (
+        f"http://test-doc-download-api/services/{service_id}/documents/{document_id}?key={key}&filename={filename}"
+    )
+    assert response.location == expected_url
+
+
+def test_landing_redirects_to_download_file_no_filename(client):
+    service_id = uuid4()
+    document_id = uuid4()
+    key = '1234'
+
+    response = client.get(
+        url_for(
+            'main.landing',
+            service_id=service_id,
+            document_id=document_id,
+            key=key,
+        )
+    )
+    assert response.status_code == 302
+    assert response.headers['X-Robots-Tag'] == 'noindex, nofollow'
+    expected_url = (
+        f"http://test-doc-download-api/services/{service_id}/documents/{document_id}?key={key}"
+    )
+    assert response.location == expected_url
+
+
+@skip_if_direct_download
 def test_landing_page_notifications_api_error(client, mocker, sample_service):
     mocker.patch('app.service_api_client.get_service', return_value={'data': sample_service})
     mocker.patch('app.service_api_client.get_service', side_effect=HTTPError(response=Mock(status_code=404)))
@@ -40,6 +87,7 @@ def test_landing_page_notifications_api_error(client, mocker, sample_service):
     assert response.status_code == 404
 
 
+@skip_if_direct_download
 def test_landing_page_creates_link_for_document(client, mocker, sample_service):
     mocker.patch('app.service_api_client.get_service', return_value={'data': sample_service})
     service_id = uuid4()
@@ -64,6 +112,7 @@ def test_landing_page_creates_link_for_document(client, mocker, sample_service):
     )
 
 
+@skip_if_direct_download
 def test_landing_page_creates_link_for_document_with_filename(client, mocker, sample_service):
     mocker.patch('app.service_api_client.get_service', return_value={'data': sample_service})
     service_id = uuid4()
@@ -90,6 +139,7 @@ def test_landing_page_creates_link_for_document_with_filename(client, mocker, sa
     )
 
 
+@skip_if_direct_download
 def test_download_document_creates_link_to_actual_doc_from_api(client, mocker, sample_service):
     mocker.patch('app.service_api_client.get_service', return_value={'data': sample_service})
     service_id = uuid4()
@@ -115,6 +165,7 @@ def test_download_document_creates_link_to_actual_doc_from_api(client, mocker, s
     )
 
 
+@skip_if_direct_download
 def test_download_document_creates_link_to_actual_doc_from_api_with_filename(
     client,
     mocker,
@@ -149,6 +200,7 @@ def test_download_document_creates_link_to_actual_doc_from_api_with_filename(
     )
 
 
+@skip_if_direct_download
 def test_download_document_shows_contact_information(client, mocker, sample_service):
     mocker.patch('app.service_api_client.get_service', return_value={'data': sample_service})
     service_id = uuid4()
@@ -172,6 +224,7 @@ def test_download_document_shows_contact_information(client, mocker, sample_serv
     assert contact_link['href'] == 'https://sample-service.gov.uk'
 
 
+@skip_if_direct_download
 @pytest.mark.parametrize('view', ['main.landing', 'main.download_document'])
 def test_pages_are_not_indexed(view, client, mocker, sample_service):
     mocker.patch('app.service_api_client.get_service', return_value={'data': sample_service})
@@ -192,6 +245,7 @@ def test_pages_are_not_indexed(view, client, mocker, sample_service):
     assert response.headers['X-Robots-Tag'] == 'noindex, nofollow'
 
 
+@skip_if_direct_download
 @pytest.mark.parametrize('contact_info,type,expected_result', [
     ('https://sample-service.gov.uk', 'link', 'https://sample-service.gov.uk'),
     ('info@sample-service.gov.uk', 'email', 'mailto:info@sample-service.gov.uk'),

--- a/tests/app/main/views/test_set_lang.py
+++ b/tests/app/main/views/test_set_lang.py
@@ -3,7 +3,10 @@ from uuid import uuid4
 from bs4 import BeautifulSoup
 from flask import url_for
 
+from tests.conftest import skip_if_direct_download
 
+
+@skip_if_direct_download
 def test_landing_page_en(client, mocker, sample_service):
     mocker.patch('app.service_api_client.get_service', return_value={'data': sample_service})
     service_id = uuid4()
@@ -26,6 +29,7 @@ def test_landing_page_en(client, mocker, sample_service):
     assert button.text.strip() == 'Français'
 
 
+@skip_if_direct_download
 def test_landing_page_fr(client, mocker, sample_service):
     mocker.patch('app.service_api_client.get_service', return_value={'data': sample_service})
     service_id = uuid4()

--- a/tests/app/test_errorhandlers.py
+++ b/tests/app/test_errorhandlers.py
@@ -4,6 +4,8 @@ from bs4 import BeautifulSoup
 from flask import url_for
 from flask_wtf.csrf import CSRFError
 
+from tests.conftest import skip_if_direct_download
+
 
 def test_bad_url_returns_page_not_found(client):
     response = client.get('/bad_url')
@@ -12,6 +14,7 @@ def test_bad_url_returns_page_not_found(client):
     assert page.h1.string.strip() == 'Page could not be found'
 
 
+@skip_if_direct_download
 def test_csrf_returns_400(client, mocker, sample_service):
     # we turn off CSRF handling for tests, so fake a CSRF response here.
     csrf_err = CSRFError('400 Bad Request: The CSRF tokens do not match.')

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -1,6 +1,8 @@
+from uuid import uuid4
+
 import pytest
 
-from app.utils import assess_contact_type, get_cdn_domain
+from app.utils import assess_contact_type, download_link, get_cdn_domain
 
 
 def test_get_cdn_domain_on_localhost(client, mocker):
@@ -30,3 +32,25 @@ def test_get_cdn_domain_on_non_localhost(client, mocker):
 )
 def test_assess_contact_type_recognises_email_phone_and_link(contact_info, expected_result):
     assert assess_contact_type(contact_info) == expected_result
+
+
+def test_download_link(client):
+    service_id = uuid4()
+    document_id = uuid4()
+    key = '1234'
+    filename = 'filename.pdf'
+    expected_url = (
+        f"http://test-doc-download-api/services/{service_id}/documents/{document_id}?key={key}&filename={filename}"
+    )
+    assert download_link(service_id, document_id, key, filename) == expected_url
+
+
+def test_download_link_no_filename(client):
+    service_id = uuid4()
+    document_id = uuid4()
+    key = '1234'
+    filename = None
+    expected_url = (
+        f"http://test-doc-download-api/services/{service_id}/documents/{document_id}?key={key}"
+    )
+    assert download_link(service_id, document_id, key, filename) == expected_url

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,13 @@ from flask import Flask
 
 from app import create_app
 
+FEATURE_REDIRECT_TO_FILE = True
+
+skip_if_direct_download = pytest.mark.skipif(
+    FEATURE_REDIRECT_TO_FILE,
+    reason="Redirecting directly to file"
+)
+
 
 @pytest.fixture
 def app_(request):


### PR DESCRIPTION
Skip the landing page, redirect directly to download the page.

Keep the old logic around but skip tests that are not relevant at the moment.

Trello: https://trello.com/c/DNegsjx6/421-skip-landing-and-redirect-directly-to-download-files