### PR TITLE
Removed previous pr bot secrets and usage

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -55,9 +55,6 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       run: |
         kubectl set image deployment.apps/document-download-frontend document-download-frontend=$DOCKER_SLUG:${GITHUB_SHA::7} -n=notification-canada-ca --kubeconfig=$HOME/.kube/config
-    - uses: cds-snc/notification-pr-bot@master
-      env:
-        TOKEN: ${{ secrets.PR_BOT_TOKEN }}
 
     - name: my-app-install token
       id: notify-pr-bot


### PR DESCRIPTION
# Summary | Résumé

Removed previous incarnation of the pr-bot usage and secrets passing. The new one was defined but the old one simply wasn't removed. It might have been to some testing stage period and the old code was not removed.

Also removed the deprecated key `PR_BOT_TOKEN` from the project's settings.
